### PR TITLE
ci: add package-pr label automation

### DIFF
--- a/.github/scripts/sync-labels.js
+++ b/.github/scripts/sync-labels.js
@@ -65,6 +65,11 @@ const LABEL_DEFINITIONS = [
         description: 'Must be resolved before the next release can ship'
     },
     {
+        name: 'package-pr',
+        color: 'bfd4f2',
+        description: 'Command: run pnpm package for this PR and push the refreshed dist artifact'
+    },
+    {
         name: 'dependencies',
         color: '0366d6',
         description: 'Patch: dependency update'

--- a/.github/workflows/package-pr.yml
+++ b/.github/workflows/package-pr.yml
@@ -1,7 +1,7 @@
 name: package PR
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - labeled
 

--- a/.github/workflows/package-pr.yml
+++ b/.github/workflows/package-pr.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      issues: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -56,3 +57,20 @@ jobs:
           git add dist/index.js
           git commit -m "chore: refresh packaged dist"
           git push origin "HEAD:${BRANCH_NAME}"
+      - name: Remove package-pr label
+        if: ${{ always() }}
+        uses: actions/github-script@v9
+        with:
+          #language=javascript
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                ...context.repo,
+                issue_number: context.payload.pull_request.number,
+                name: 'package-pr'
+              });
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+            }

--- a/.github/workflows/package-pr.yml
+++ b/.github/workflows/package-pr.yml
@@ -1,7 +1,7 @@
 name: package PR
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - labeled
 

--- a/.github/workflows/package-pr.yml
+++ b/.github/workflows/package-pr.yml
@@ -1,0 +1,58 @@
+name: package PR
+
+on:
+  pull_request_target:
+    types:
+      - labeled
+
+concurrency:
+  cancel-in-progress: true
+  group: package-pr-${{ github.event.pull_request.number }}
+
+jobs:
+  package_pr:
+    name: Package PR branch
+    if: ${{ github.event.label.name == 'package-pr' && github.event.pull_request.head.repo.full_name == github.repository }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: '.nvmrc'
+          cache: pnpm
+      - run: pnpm dlx @aikidosec/safe-chain@1.1.9 setup-ci
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm run package
+      - name: Verify packaging only changed the bundled artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          unexpected_files="$(git diff --name-only -- . ':(exclude)dist/index.js')"
+          if [[ -n "${unexpected_files}" ]]; then
+            echo "::error::Packaging changed tracked files other than dist/index.js:"
+            echo "${unexpected_files}"
+            exit 1
+          fi
+      - name: Commit packaged dist when needed
+        shell: bash
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+
+          if git -c core.autocrlf=false diff --ignore-cr-at-eol --quiet -- dist/index.js; then
+            echo "dist/index.js already matches pnpm run package output."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add dist/index.js
+          git commit -m "chore: refresh packaged dist"
+          git push origin "HEAD:${BRANCH_NAME}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,8 @@ The release-label workflow tries to apply labels automatically. It fails only if
 
 The repository intentionally does not use body-content issue labeling. Issue forms plus a default `triage` label keep incoming issue state predictable and avoid overfitting labels to partial text matches.
 
+Maintainers can add the `package-pr` label to a same-repository pull request to run `pnpm run package` in CI and push a refreshed committed `dist/index.js` back to the PR branch. This label is command-style automation, not a release/changelog label.
+
 ## Issue Intake and Triage
 
 New issues should come through the GitHub issue forms for:

--- a/dist/index.js
+++ b/dist/index.js
@@ -6,6 +6,7 @@
 
 "use strict";
 
+
 /* eslint-disable @typescript-eslint/no-explicit-any */
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
@@ -21,8 +22,10 @@ var __createBinding = (this && this.__createBinding) || (Object.create ? (functi
 var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
     Object.defineProperty(o, "default", { enumerable: true, value: v });
 }) : function(o, v) {
-    o["default"] = v;
+    o["default"] = v   ;
 });
+
+
 var __importStar = (this && this.__importStar) || (function () {
     var ownKeys = function(o) {
         ownKeys = Object.getOwnPropertyNames || function (o) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -6,7 +6,6 @@
 
 "use strict";
 
-
 /* eslint-disable @typescript-eslint/no-explicit-any */
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
@@ -22,10 +21,8 @@ var __createBinding = (this && this.__createBinding) || (Object.create ? (functi
 var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
     Object.defineProperty(o, "default", { enumerable: true, value: v });
 }) : function(o, v) {
-    o["default"] = v   ;
+    o["default"] = v;
 });
-
-
 var __importStar = (this && this.__importStar) || (function () {
     var ownKeys = function(o) {
         ownKeys = Object.getOwnPropertyNames || function (o) {


### PR DESCRIPTION
### What
- add a `package-pr` label to the synced repository labels
- add a `pull_request_target` workflow that runs `pnpm run package` when that label is added to a same-repo PR
- document the command-style label in CONTRIBUTING

### Why
- give maintainers a deliberate way to regenerate and push committed package output onto an open PR branch
- keep the automation scoped away from fork PRs and unrelated tracked-file changes

### Validation
- `pnpm run eslint`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run package`

### Notes
- the workflow only pushes when packaging changes `dist/index.js`
- the workflow fails if packaging changes other tracked files