### PR TITLE
ci: retry package-pr workflow permissions

### DIFF
--- a/.github/workflows/package-pr.yml
+++ b/.github/workflows/package-pr.yml
@@ -1,7 +1,7 @@
 name: package PR
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - labeled
 
@@ -17,8 +17,9 @@ jobs:
     permissions:
       contents: write
       issues: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           fetch-depth: 0

--- a/dist/index.js
+++ b/dist/index.js
@@ -23,6 +23,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 }) : function(o, v) {
     o["default"] = v;
 });
+
 var __importStar = (this && this.__importStar) || (function () {
     var ownKeys = function(o) {
         ownKeys = Object.getOwnPropertyNames || function (o) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -23,7 +23,6 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 }) : function(o, v) {
     o["default"] = v;
 });
-
 var __importStar = (this && this.__importStar) || (function () {
     var ownKeys = function(o) {
         ownKeys = Object.getOwnPropertyNames || function (o) {


### PR DESCRIPTION
### What
- switch the `package-pr` workflow back to `pull_request`
- grant `pull-requests: write` in addition to `issues: write` for the label cleanup step
- align `actions/checkout` with the repo standard at `v7`

### Why
- test whether the label-removal failure was caused by missing pull-request write permission in the PR-triggered workflow context
- keep this experiment isolated from the already-merged branch so the behavior can be verified cleanly

### Validation
- `pnpm run eslint`
- `pnpm run typecheck`
- `pnpm run test`
- `pnpm run package`

### Notes
- local `pnpm run package` still rewrote `dist/index.js`, but that generated diff was not included in this branch
- this PR is intended only to validate workflow behavior when the `package-pr` label is applied